### PR TITLE
Fix CSS & search

### DIFF
--- a/book.json
+++ b/book.json
@@ -3,6 +3,9 @@
   "title": "Cadasta FAQ",
   "description": "Commonly asked questions regarding the Cadasta Platform.",
   "plugins": ["theme-faq", "advanced-emoji"],
+  "styles": {
+    "website": "_css/cadasta.css"
+  },
   "structure": {
     "readme": "home.md",
     "summary": "toc.md"

--- a/src/_layouts/website/layout.html
+++ b/src/_layouts/website/layout.html
@@ -20,7 +20,6 @@
         integrity="sha384-I6JCnqxMbC2DuiHjsoCiLa15NVbKRf8/ooANRLsXD87zD2dVqzlz6Oqjvj470ztk"
         crossorigin="anonymous">
     <link rel="stylesheet" href="{{ "style.css"|resolveAsset }}">
-    <link rel="stylesheet" href="/_css/cadasta.css">
     {{ super() }}
     {% for type, style in config.styles %}
         {% if fileExists(style) and type == "website" %}
@@ -35,7 +34,7 @@
         <div class="navbar-header">
             <a class="navbar-brand" href="https://cadasta.org">
                 <img src="http://assets.cadasta.org/logo/Color_Logo/Rectangular/logo_color_200x71/logo_color_200x71.png" width="200" height="71" alt="Cadasta">
-            </a>      
+            </a>
         </div>
         <div class="navbar-default">
             <ul class="nav navbar-nav">

--- a/src/_layouts/website/page.html
+++ b/src/_layouts/website/page.html
@@ -1,3 +1,4 @@
+{% extends template.self %}
 {% extends "website/layout.html" %}
 
 {% block title %}


### PR DESCRIPTION
This PR fixes two problems:

* The CSS import was failing for URLs where the FAQ is not served at root (e.g. https://cadasta.github.io/cadasta-faq). Looking at the template, it seems that the idiomatic way to add the style is via `config.styles`:
https://github.com/Cadasta/cadasta-faq/blob/18ea0b1186dc83d9bab90bc12f03dafa1ac97aca/src/_layouts/website/layout.html#L25-L29
This automatically handles the import of the stylesheet on subpages (e.g. run `npm run docs:build` and you'll see that in `_book/add_field/index.html` the stylesheet path is correctly referenced as `<link rel="stylesheet" href="../gitbook/style.css">`
* The search bar was not appearing in the built  docs.  This seems to be the same thing mentioned in GitbookIO/plugin-search#6.  Adding `{% extends template.self %}` fixes this.