### PR TITLE
Clearer text

### DIFF
--- a/src/_css/cadasta.css
+++ b/src/_css/cadasta.css
@@ -1,13 +1,22 @@
 @import url("https://fonts.googleapis.com/css?family=Roboto|Roboto+Condensed");
 
+* {
+  -webkit-overflow-scrolling: touch;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-text-size-adjust: none;
+  -webkit-touch-callout: none;
+  -webkit-font-smoothing: antialiased;
+}
+
 body {
-    font-family: Roboto;
-    color: #595a5c;
+  font-family: Roboto;
+  color: #595a5c;
+  text-rendering: optimizeLegibility;
 }
 
 h1 {
-    font-family: Roboto Condensed,Roboto,sans-serif;
-    color: #0e305e;
+  font-family: Roboto Condensed, Roboto, sans-serif;
+  color: #0e305e;
 }
 
 a,


### PR DESCRIPTION
Comparing the standard FAQ Template to our custom template, I noticed that the text wasn't as crisp. A quick look into the default template showed that it leaned on some CSS directives to make the text cleaner (if using Chrome).

### Before
![Screen Shot 2019-03-18 at 5 01 26 PM](https://user-images.githubusercontent.com/897290/54569325-017bdb00-49a0-11e9-9f42-0528a0972b3f.png)

### After

![Screen Shot 2019-03-18 at 5 00 35 PM](https://user-images.githubusercontent.com/897290/54569289-e1e4b280-499f-11e9-844c-fdd650d64459.png)
