### PR TITLE
Make email address render as link

### DIFF
--- a/src/home.md
+++ b/src/home.md
@@ -2,5 +2,4 @@
 This is the landing page. The content below will be visible on the FAQ's homepage.
 -->
 
-**Welcome to Cadasta's Frequently Asked Questions (FAQ) page**. Browse through the list below to find answers to commonly raised questions when using our digital tools. Need more assistance? Reach out to us at support@cadasta.org. 
-
+**Welcome to Cadasta's Frequently Asked Questions (FAQ) page**. Browse through the list below to find answers to commonly raised questions when using our digital tools. Need more assistance? Reach out to us at <support@cadasta.org>.


### PR DESCRIPTION
I assumed  that the email link in the welcome text would be automatically rendered as a link.  I was mistaken.  Enclosing it in `<>` does the trick.

### Before

![Screen Shot 2019-03-19 at 10 30 21 AM](https://user-images.githubusercontent.com/897290/54623898-07ba9780-4a32-11e9-959e-2f6e8e82ac14.png)


### After

![Screen Shot 2019-03-19 at 10 30 17 AM](https://user-images.githubusercontent.com/897290/54623910-0be6b500-4a32-11e9-820f-76e4aa9ad91d.png)
