### PR TITLE
Load assets via https

### DIFF
--- a/src/_layouts/website/layout.html
+++ b/src/_layouts/website/layout.html
@@ -33,7 +33,7 @@
     <div class="container">
         <div class="navbar-header">
             <a class="navbar-brand" href="https://cadasta.org">
-                <img src="http://assets.cadasta.org/logo/Color_Logo/Rectangular/logo_color_200x71/logo_color_200x71.png" width="200" height="71" alt="Cadasta">
+                <img src="https://assets.cadasta.org/logo/Color_Logo/Rectangular/logo_color_200x71/logo_color_200x71.png" width="200" height="71" alt="Cadasta">
             </a>
         </div>
         <div class="navbar-default">


### PR DESCRIPTION
Tiny change to load the Cadasta logo via https from the `assets` bucket. 

**Why the change**

- I enabled `faq.cadasta.org` for the GitHub page, also enforcing https.
- When loading graphics from a http source, the site in not considered secure, hence the change
- I further set up up a Cloudfront distribution for the `assets.cadasta.org` bucket, which uses the `*.cadasta.org` SSL certificate so we can serve the contents of `assets.cadasta.org` via https. 