### PR TITLE
Add CNAME

### DIFF
--- a/src/CNAME
+++ b/src/CNAME
@@ -1,0 +1,1 @@
+faq.cadasta.org


### PR DESCRIPTION
The deployment to `gh-pages` removes the `CNAME` at every deploy. That’s why we’re seeing these `404` after a redeploy. (See: https://github.com/Cadasta/cadasta-faq/commit/f028ac7b0daec3a132d0a8eb5f1c8c32373d16c5). 

`CNAME` should be part of the repo so it's not removed everytime we deploy. 